### PR TITLE
BOJ : 2293 G5 동전

### DIFF
--- a/eunjin/src/week3/BOJ_2293_G5_동전.java
+++ b/eunjin/src/week3/BOJ_2293_G5_동전.java
@@ -1,0 +1,30 @@
+package week3;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_2293_G5_동전 {
+
+	static int N, K;
+	static int[] dp;
+	static int count;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken());
+		dp = new int[K+1];
+		dp[0] = 1;
+		for(int i=0; i<N; i++) {
+			int coin = Integer.parseInt(br.readLine());
+			for (int j = coin; j < K+1; j++) {
+				dp[j] = dp[j-coin]+dp[j];
+			}
+		}
+		
+		System.out.println(dp[K]);
+	}
+}


### PR DESCRIPTION
## BOJ 2293 동전 1
- 다이나믹 프로그래밍
- https://www.acmicpc.net/problem/2293



## 풀이

예시)
3 10
1
2
5

3개의 동전 1원, 2원, 5원을 이용하여 10원을 만들 수 있는 동전의 경우의 수를 구하는 문제에서

1원으로 만들 수 있는 돈의 경우의 수를 구하고,
2원으로 만들 수 있는 돈의 경우의 수를 현재 테이블을 이용하여 구하고,
5원으로 만들 수 있는 돈의 경우의 수를 현재 테이블을 이용하여 구하였습니다.

dp[j] = dp[j-coin]+dp[j];

위의 로직으로 풀었습니다.

~~~java
dp = new int[K+1];
dp[0] = 1;
for(int i=0; i<N; i++) {
	int coin = Integer.parseInt(br.readLine());
	for (int j = coin; j < K+1; j++) {
		dp[j] = dp[j-coin]+dp[j];
	}
}
~~~

## 소스코드
~~~java
package week3;

import java.io.BufferedReader;
import java.io.IOException;
import java.io.InputStreamReader;
import java.util.StringTokenizer;

public class BOJ_2293_G5_동전 {

	static int N, K;
	static int[] dp;
	static int count;
	
	public static void main(String[] args) throws IOException {
		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
		StringTokenizer st = new StringTokenizer(br.readLine());
		N = Integer.parseInt(st.nextToken());
		K = Integer.parseInt(st.nextToken());
		dp = new int[K+1];
		dp[0] = 1;
		for(int i=0; i<N; i++) {
			int coin = Integer.parseInt(br.readLine());
			for (int j = coin; j < K+1; j++) {
				dp[j] = dp[j-coin]+dp[j];
			}
		}
		
		System.out.println(dp[K]);
	}
}
~~~

## 결과 

| 메모리  | 시간 |
|----|----|
| 14332KB| 140ms|

