### PR TITLE
MYEONGGYU : PG LV2 두 큐 합 같게 만들기

### DIFF
--- a/myeonggyu/src/week11/BOJ_1405_G5_미친로봇.java
+++ b/myeonggyu/src/week11/BOJ_1405_G5_미친로봇.java
@@ -1,0 +1,94 @@
+package week11;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.StringTokenizer;
+
+public class BOJ_1405_G5_미친로봇 {
+
+	static int n;
+	static double[] arr;
+	static int[] perm = {0,1,2,3};
+	static int[][] diff = {{0,1},{0,-1},{1,0},{-1,0}};
+	static int[] tmp;
+	static double total;
+	static int m = 29;
+	static int total_cnt;
+//	static HashSet<Integer> set = new HashSet<>();
+	static boolean[][] visited;
+	
+	public static void main(String[] args) throws IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		n = Integer.parseInt(st.nextToken());
+		arr = new double[4];
+		
+		for (int i = 0; i < 4; i++) {
+			arr[i] = Double.parseDouble(st.nextToken())/100.0;
+		}
+		
+		tmp = new int[n];
+		total = 0;
+//		set.add(14*m+14);
+		visited = new boolean[m][m]; 
+		visited[14][14] = true;
+		perm(0, 14, 14);
+//		total_cnt = (int) Math.pow(4, n);
+//		double ans = (double)total/(double)total_cnt;
+//		ans  = ans * 
+		System.out.println(total);
+//		System.out.println(total_cnt);
+	
+
+	}
+
+	private static void perm(int cnt, int r, int c) {
+		
+		if(cnt == n) {
+			cal();
+		}
+		
+		else {
+			
+			for (int i = 0; i < 4; i++) {
+				tmp[cnt] = perm[i];
+				int[] d = diff[tmp[cnt]];
+				int nr = r+d[0];
+				int nc = c+d[1];
+				if(visited[nr][nc])
+					continue;
+				
+				visited[nr][nc] = true;
+				perm(cnt+1, nr,nc);
+				visited[nr][nc] = false;
+				total_cnt++;
+			}
+			
+			
+		}
+		
+		
+	}
+
+	private static void cal() {
+		
+		double per = 1;
+		for (int i = 0; i < n; i++) {
+			int idx = tmp[i];
+			double percent = arr[idx];
+			
+			per *= percent;
+			
+		}
+		
+		total += per;
+		
+	}
+
+
+}

--- a/myeonggyu/src/week11/BOJ_14719_G5_빗물.java
+++ b/myeonggyu/src/week11/BOJ_14719_G5_빗물.java
@@ -1,0 +1,94 @@
+package week11;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ_14719_G5_빗물 {
+
+	static int[][] map;
+	static int n;
+	static int m;
+	static int sum;
+	
+	public static void main(String[] args) throws IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		
+		st = new StringTokenizer(br.readLine());
+		
+		map = new int[n][m];
+		
+		int max = 0;
+		for (int i = 0; i < m; i++) {
+			int v= Integer.parseInt(st.nextToken());
+			max = Math.max(v, max);
+			for (int j = 0; j < v; j++) {
+				map[j][i] = 1;
+			}
+		}
+		
+
+//		for (int[] a : map) {
+//			System.out.println(Arrays.toString(a));
+//		}
+		
+		for (int i = 0; i < max; i++) {
+			for (int j = 0; j < m; j++) {
+				if(map[i][j] == 1)
+					continue;
+				
+				
+				check(i,j);
+			}
+		}
+		
+		System.out.println(sum);
+						
+		
+		
+
+	}
+
+	private static void check(int i, int j) {
+		
+		int leftCol = j-1;
+		int rightCol = j+1;
+		int cnt = 1;
+		ArrayList<Integer> p = new ArrayList<>();
+		p.add(j);
+		while(leftCol  >= 0 && map[i][leftCol] != 1) {
+
+			p.add(leftCol);
+			leftCol--;
+			cnt++;
+		}
+		
+		if(leftCol == -1)
+			return;
+		
+		while(rightCol < m && map[i][rightCol] != 1) {
+
+			p.add(rightCol);
+			rightCol++;
+			cnt++;
+		}
+		
+		if(rightCol == m)
+			return;
+		
+		sum += cnt;
+		for (Integer integer : p) {
+			map[i][integer] = 1;
+		}
+		
+	}
+
+}

--- a/myeonggyu/src/week11/BOJ_2573_G4_빙산.java
+++ b/myeonggyu/src/week11/BOJ_2573_G4_빙산.java
@@ -1,0 +1,165 @@
+package week11;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+import java.util.concurrent.LinkedBlockingDeque;
+
+public class BOJ_2573_G4_빙산 {
+
+	static int n;
+	static int m;
+	static int[][][] map;
+	static ArrayList<Integer> glace;
+	static int[][] diff = {{1,0},{0,1},{-1,0},{0,-1}};
+	static int step;
+	static int count;
+	
+	public static void main(String[] args) throws IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		glace = new ArrayList<>();
+		step = 0;
+		count = 0;
+		map = new int[n][m][2];
+		for (int i = 0; i < n; i++) {
+			st = new StringTokenizer(br.readLine());
+			
+			for (int j = 0; j < m; j++) {
+				map[i][j][0] = Integer.parseInt(st.nextToken());
+				map[i][j][1] = map[i][j][0];
+				if(map[i][j][0] != 0)
+					glace.add(i*m+j);
+			}
+		}
+
+		
+		while(true) {
+
+
+			unfreeze();
+			count++;
+
+			if(glace.size() == 0) {
+				count = 0;
+				break;
+			}
+			if(!check_map())
+				break;
+		}
+		
+		System.out.println(count);
+		
+	}
+
+	private static boolean check_map() {
+		
+		int v = glace.get(0);
+		HashSet<Integer> set = new HashSet<>();
+		
+		Queue<Integer> queue = new LinkedList<>();
+		queue.offer(v);
+		set.add(v);
+		
+		while(!queue.isEmpty()) {
+			
+			v = queue.poll();
+			int r = v/m;
+			int c = v%m;
+			
+			for (int[] d : diff) {
+				
+				int nr = r + d[0];
+				int nc = c + d[1];
+				
+				if(!check(nr,nc))
+					continue;
+				
+				if(map[nr][nc][step] == 0)
+					continue;
+				
+				int x = nr*m+nc;
+				if(set.contains(x))
+					continue;
+				
+				queue.offer(x);
+				set.add(x);
+				
+			}
+			
+		}
+		
+		
+		if(set.size() != glace.size())
+			return false;
+		else
+			return true;
+		
+		
+	}
+
+	private static void unfreeze() {
+		
+		int next_step = (step+1)%2;
+		int k = glace.size();
+		for (int i = 0; i < k; i++) {
+			
+			int v = glace.get(i);
+			int r = v/m;
+			int c = v%m;
+			
+			int cnt = 0;
+			for (int[] d : diff) {
+				
+				int nr = r+d[0];
+				int nc = c+d[1];
+				
+				if(!check(nr,nc))
+					continue;
+				
+				if(map[nr][nc][step] != 0)
+					continue;
+				
+				cnt++;
+				
+			}
+			
+			map[r][c][next_step] = Math.max(map[r][c][step] - cnt,0);			
+			
+			
+		}
+		
+		
+		for (int i = 0; i < k; i++) {
+			int v = glace.get(i);
+			int r = v/m;
+			int c = v%m;
+			if(map[r][c][next_step] == 0) {
+				map[r][c][step] = 0;
+				glace.remove(i--);
+				k--;
+				continue;
+			}
+		}
+
+		step = next_step;
+		
+	}
+
+	private static boolean check(int nr, int nc) {
+		return 0 <= nr && nr < n && 0 <= nc && nc < m;
+	}
+
+	
+
+}

--- a/myeonggyu/src/week11/SWEA_5653_모의_줄기세포배양.java
+++ b/myeonggyu/src/week11/SWEA_5653_모의_줄기세포배양.java
@@ -1,0 +1,150 @@
+package week11;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class SWEA_5653_모의_줄기세포배양 {
+	
+	
+	static int n;
+	static int m;
+	static int k;
+	static HashMap<Integer, int[]> cells;
+	static HashMap<Integer, Integer> spreadCells;
+	static HashSet<Integer> deadCell;
+	
+	static int row;
+	static int col;
+	
+	static int[][] diff = {{0,1},{1,0},{-1,0},{0,-1}};
+	
+
+	
+	
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int T = Integer.parseInt(br.readLine());
+		
+		for (int t = 1; t <= T; t++) {
+			
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			n = Integer.parseInt(st.nextToken());
+			m = Integer.parseInt(st.nextToken());
+			k = Integer.parseInt(st.nextToken());
+			cells = new HashMap<>();
+			spreadCells = new HashMap<>();
+			deadCell = new HashSet<>();
+			
+			row = 351;
+			col = 351;
+			
+			for (int i = 0; i < n; i++) {
+				st = new StringTokenizer(br.readLine());
+				for (int j = 0; j < m; j++) {
+					
+					int v = Integer.parseInt(st.nextToken());
+					if(v==0)
+						continue;
+					cells.put((150+i)*351+(j+150), new int[] {v,v});
+				}
+			}
+			
+			for (int nn = 0; nn < k; nn++) {
+				
+				activate();
+				spread();
+//				System.out.println(cells.size());
+				
+				
+			}
+			System.out.println("#" + t + " " + cells.size());
+			
+		}
+		
+	}
+
+	private static void spread() {
+		
+		Queue<Integer> queue = new LinkedList<>();
+		
+		
+		for (Integer key : cells.keySet()) {
+			
+			int[] v = cells.get(key);
+			
+			//만약 활성화 된 셀이라면 퍼트리고 죽여
+			if(v[1] == -1) {
+				
+				int r = key/col;
+				int c = key%col;
+				
+				for (int[] d: diff) {
+					
+					int nr = r + d[0];
+					int nc = c + d[1];
+					int nkey = nr*col + nc;
+					
+					//죽은셀이면 컨티뉴
+					if(deadCell.contains(nkey))
+						continue;
+					
+					//이미 들어있는 셀이면 컨티뉴
+					if(cells.containsKey(nkey))
+						continue;
+					
+					//이번턴에 퍼진셀과 겹치면
+					if(spreadCells.containsKey(nkey)) {
+						//그 퍼진 셀이 지금 퍼질 셀보다 크면 컨티뉴
+						if(spreadCells.get(nkey) > v[0])
+							continue;
+						
+							
+					}
+					
+					//죽은셀 아니고 이미 배치된 셀 아니거나 이번턴에 퍼진 셀보다 지금 셀이 더 크면 업데이트
+					spreadCells.put(nkey, v[0]);
+					
+				}
+				
+				
+				
+				
+			}
+			
+			if(v[1]*-1 == v[0]) {
+				deadCell.add(key);
+				queue.offer(key);					
+			}
+			
+		}
+		
+		for (Integer key : queue) {
+			cells.remove(key);
+		}
+		
+		for (Integer key : spreadCells.keySet()) {
+			cells.put(key, new int[] {spreadCells.get(key),spreadCells.get(key)});
+		}
+		
+		spreadCells = new HashMap<>();
+		
+	}
+
+	private static void activate() {
+		
+		int i = 0;
+		for (Integer key : cells.keySet()) {
+			
+			cells.get(key)[1] -= 1;
+		}
+	}
+
+}

--- a/myeonggyu/src/week12/BOJ_20546_S5_기적의매매법.java
+++ b/myeonggyu/src/week12/BOJ_20546_S5_기적의매매법.java
@@ -1,0 +1,89 @@
+package week12;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_20546_S5_기적의매매법 {
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int cash = Integer.parseInt(br.readLine());
+		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int n = 14;
+		int[] arr = new int[n];
+		
+		int jun = cash;
+		int jCnt = 0;
+		int sung = cash;
+		int sCnt = 0;
+		
+		int state = 0;
+		
+		for (int i = 0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+			
+			//준현이
+			while(jun-arr[i] >=0) {
+				jun-= arr[i];
+				jCnt++;
+			}
+			
+			
+			
+			//성민이
+			if(i >= 1) {
+				
+				
+				if(state >= 0)
+					if(arr[i] > arr[i-1])
+						state++;
+					else if(arr[i] == arr[i-1])
+						state = 0;
+					else
+						state = -1;
+				else{
+					if(arr[i] > arr[i-1])
+						state = 1;
+					else if(arr[i] == arr[i-1])
+						state = 0;
+					else {
+						state--;
+					}
+				}
+			}
+			//사야한다면
+			if(state <= -3) {
+				while(sung-arr[i] >=0) {
+					sung-=arr[i];
+					sCnt++;
+				}
+			}
+			//팔아야하면
+			else if(state >= 3) {
+				while(sCnt != 0) {
+					sung += arr[i];
+					sCnt--;
+				}
+			}
+		}
+		
+		int junTotal = jun+(jCnt*arr[n-1]);
+		int sungTotal = sung+(sCnt*arr[n-1]);
+		
+//		System.out.println(junTotal +" " + sungTotal);
+		
+		if(junTotal == sungTotal)
+			System.out.println("SAMESAME");
+		else if(junTotal < sungTotal)
+			System.out.println("TIMING");
+		else
+			System.out.println("BNP");
+		
+		
+	}
+
+}

--- a/myeonggyu/src/week12/BOJ_2436_G5_공약수.java
+++ b/myeonggyu/src/week12/BOJ_2436_G5_공약수.java
@@ -1,0 +1,49 @@
+package week12;
+
+import java.util.Scanner;
+
+public class BOJ_2436_G5_공약수 {
+
+	public static void main(String[] args) {
+		
+		Scanner sc = new Scanner(System.in);
+		int x = sc.nextInt();
+		int y = sc.nextInt();
+		
+		int tmp = y/x;
+		int mins = Integer.MAX_VALUE;
+		int ra = 0;
+		int rb = 0;
+		for (int i = 1; i <= tmp ; i++) {
+			int a = i;
+			if(tmp%i != 0)
+				continue;
+			int b = tmp/i;
+			
+			if(GCD(Math.max(a, b),Math.min(a, b)) != 1) {
+				continue;
+			}
+			
+			if(mins > a+b) {
+				mins = a+b;
+				ra = a;
+				rb = b;
+			}
+		}
+		ra *= x;
+		rb *= x;
+		System.out.println(Math.min(ra, rb)+" "+ Math.max(ra, rb));
+		
+	}
+	
+	static int GCD(int a,int b){
+	    while(true){
+	        int r = a%b;
+	        if(r==0) return b;
+			
+	        a = b;
+	        b = r;
+	    }
+	}
+
+}

--- a/myeonggyu/src/week12/BOJ_2564_S1_경비원.java
+++ b/myeonggyu/src/week12/BOJ_2564_S1_경비원.java
@@ -1,0 +1,94 @@
+package week12;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+
+public class BOJ_2564_S1_경비원 {
+	
+	public static void main(String[] args) throws IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int m = Integer.parseInt(st.nextToken());
+		int n = Integer.parseInt(st.nextToken());
+		int k = Integer.parseInt(br.readLine());
+		int[][] arr = new int[k][2];
+		for (int i = 0; i < k; i++) {
+			st = new StringTokenizer(br.readLine());
+			int v = Integer.parseInt(st.nextToken());
+			
+			arr[i] = new int[] {v,Integer.parseInt(st.nextToken())};
+			
+		}
+		st = new StringTokenizer(br.readLine());
+		int v = Integer.parseInt(st.nextToken());
+		int[] my = new int[] {v,Integer.parseInt(st.nextToken())};
+		int sums = 0;
+		for (int i = 0; i < k; i++) {
+			int[] cur = arr[i];
+			
+			if(cur[0]*my[0] == 2 || cur[0]*my[0] == 12) {//2면 두개가 남북, 12면 두개가 동서
+				sums += cal(cur,my,n,m);//반대편 있을 때 거리계산
+			}
+			else {
+				int[] a = make_point(my,n,m);
+				int[] b = make_point(arr[i],n,m);
+				
+				sums += (Math.abs(a[0]-b[0])+Math.abs(a[1]-b[1]));
+			}
+		}
+		
+		System.out.println(sums);
+		
+		
+	}
+
+	private static int[] make_point(int[] tmp, int n, int m) {
+		
+		int[] p = new int[2];
+		if(tmp[0] == 1)//북
+			p = new int[] {0,tmp[1]};
+		if(tmp[0]==2)//남
+			p = new int[] {n,tmp[1]};
+		if(tmp[0]==3)//서
+			p = new int[] {tmp[1],0};
+		if(tmp[0]==4)//동
+			p = new int[] {tmp[1],m};
+		return p;
+		
+	}
+
+	private static int cal(int[] cur, int[] my, int n, int m) {
+		int mins = Integer.MAX_VALUE;
+		if(cur[0]*my[0] == 2) {//남북이면
+			int left = my[1]+cur[1];
+			int right = m-my[1] + m-cur[1];
+			mins = Math.min(left, right)+n;
+		}
+		else {
+			int up = my[1]+cur[1];
+			int down = n-my[1] + m-cur[1];
+			mins = Math.min(up, down)+m;
+		}
+		return mins;
+	}
+
+	private static int make_idx(int v, int n, int m) {
+		int idx = 0;
+		if(v == 1)//북쪽 == 0
+			idx = 0;
+		if(v == 2)//남쪽
+			idx = n-1;
+		if(v == 3)//서쪽
+			idx = 0;
+		if(v == 4)//동쪽
+			idx = m-1;
+		
+		return idx;
+	}
+
+}

--- a/myeonggyu/src/week13/BOJ_12904_G5_A와B.java
+++ b/myeonggyu/src/week13/BOJ_12904_G5_A와B.java
@@ -1,0 +1,44 @@
+package week13;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Scanner;
+import java.util.Stack;
+
+public class BOJ_12904_G5_A와B {
+
+	public static void main(String[] args) {
+
+		
+		Scanner sc = new Scanner(System.in);
+		String s = sc.next();
+		char[] tmp = sc.next().toCharArray();		
+
+		ArrayList<Character> t = new ArrayList<>();
+		for (Character tt : tmp) {
+			t.add(tt);
+		}
+		while(s.length()!=t.size()) {
+			
+			if(t.get(t.size()-1) == 'A') {
+				t.remove(t.size()-1);
+			}
+			else {
+				t.remove(t.size()-1);
+				Collections.reverse(t);
+			}
+		}
+		
+		StringBuilder sb = new StringBuilder();
+		for (Character c : t) {
+			sb.append(c);
+		}
+		String ss = sb.toString();
+		if(ss.equals(s))
+			System.out.println(1);
+		else
+			System.out.println(0);
+		
+	}
+
+}

--- a/myeonggyu/src/week13/BOJ_23843_G5_콘센트.java
+++ b/myeonggyu/src/week13/BOJ_23843_G5_콘센트.java
@@ -1,0 +1,52 @@
+package week13;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class BOJ_23843_G5_콘센트 {
+
+	
+	public static void main(String[] args) throws IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int n = Integer.parseInt(st.nextToken());
+		int m = Integer.parseInt(st.nextToken());
+		
+		String[] tmp = br.readLine().split(" ");
+		
+		Integer[] arr = new Integer[tmp.length];
+		for (int i = 0; i < arr.length; i++) {
+			arr[i] = Integer.parseInt(tmp[i]);
+		}
+		Arrays.sort(arr, Collections.reverseOrder());
+		PriorityQueue<Integer> pq = new PriorityQueue<>();
+		for (int i = 0; i < m; i++) {
+			pq.offer(0);
+		}
+		
+		int cnt = 0;
+		
+		while(cnt != arr.length) {
+
+			
+			int cur = pq.poll();
+			pq.offer(cur+arr[cnt]);
+			cnt++;
+		}
+		
+		int maxs = 0;
+		int s = pq.size();
+		for (int i = 0; i < s; i++) {
+			maxs = Math.max(pq.poll(),maxs);
+		}
+		System.out.println(maxs);
+	}
+
+}

--- a/myeonggyu/src/week13/SWEA_2503_D3_베스킨라빈스N.java
+++ b/myeonggyu/src/week13/SWEA_2503_D3_베스킨라빈스N.java
@@ -1,0 +1,21 @@
+package week13;
+
+import java.util.Scanner;
+
+public class SWEA_2503_D3_베스킨라빈스N {
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		int T = sc.nextInt();
+		for (int t = 1; t <= T; t++) {
+			int n = sc.nextInt();
+			
+			if(n%4 == 1)
+				System.out.println("#" +t +" " + 1);
+			else
+				System.out.println("#" +t +" " + 0);
+		}
+	}
+	
+}
+

--- a/myeonggyu/src/week13/SWEA_4193_D4_수영대회결승전.java
+++ b/myeonggyu/src/week13/SWEA_4193_D4_수영대회결승전.java
@@ -1,0 +1,103 @@
+package week13;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class SWEA_4193_D4_수영대회결승전 {
+
+	static int n;
+	static int[][] map;
+	static int[] s;
+	static int[] e;
+	static int[][] diff = {{1,0},{0,1},{-1,0},{0,-1}};
+	
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int T = Integer.parseInt(br.readLine());
+		for (int t = 1; t <= T; t++) {
+			n = Integer.parseInt(br.readLine());
+			StringTokenizer st;
+			map = new int[n][n];
+			for (int i = 0; i < n; i++) {
+				
+				st = new StringTokenizer(br.readLine());
+				for (int j = 0; j < n; j++) {
+					map[i][j] = Integer.parseInt(st.nextToken());
+				}
+			}
+			
+			st = new StringTokenizer(br.readLine());
+			s = new int[] {Integer.parseInt(st.nextToken()),Integer.parseInt(st.nextToken())};
+
+			st = new StringTokenizer(br.readLine());
+			e = new int[] {Integer.parseInt(st.nextToken()),Integer.parseInt(st.nextToken())};
+			
+			
+			System.out.println("#" + t + " " + bfs());
+		}
+
+	}
+
+	private static int bfs() {
+
+		PriorityQueue<int[]> queue = new PriorityQueue<>(new Comparator<int[]>() {
+
+			@Override
+			public int compare(int[] o1, int[] o2) {
+				return Integer.compare(o1[2], o2[2]);
+			}
+		});
+		queue.offer(new int[] {s[0],s[1],0});
+		map[s[0]][s[1]] = -1;
+		
+		while(!queue.isEmpty()) {
+			
+			int[] cur = queue.poll();
+//			System.out.println(Arrays.toString(cur));
+			
+			for (int[] d : diff) {
+				
+				int nr = cur[0] + d[0];
+				int nc = cur[1] + d[1];
+				
+				if(!check(nr,nc))
+					continue;
+				
+				if(map[nr][nc] == -1)
+					continue;
+				
+				if(map[nr][nc] == 1)
+					continue;
+				
+				if(nr == e[0] && nc == e[1])
+					return cur[2]+1;
+				
+				
+				if(map[nr][nc] == 2) {
+					queue.offer(new int[] {nr,nc,cur[2]+3-(cur[2]%3)});
+					continue;
+				}
+				queue.offer(new int[] {nr,nc,cur[2]+1});
+				map[nr][nc] = -1;
+				
+			}
+			
+		}
+		
+		return -1;
+	}
+
+	private static boolean check(int nr, int nc) {
+		return 0 <= nr && nr < n && 0 <= nc && nc < n;
+	}
+	
+}
+

--- a/myeonggyu/src/week14/BOJ_11048_S2_이동하기.java
+++ b/myeonggyu/src/week14/BOJ_11048_S2_이동하기.java
@@ -1,0 +1,47 @@
+package week14;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_11048_S2_이동하기 {
+
+	
+	public static void main(String[] args) throws NumberFormatException, IOException {
+	
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int n = Integer.parseInt(st.nextToken());
+		int m = Integer.parseInt(st.nextToken());
+		
+		int[][] map = new int[n][m];
+		for (int i = 0; i < n; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < m; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+		
+		for (int i = 0; i < n; i++) {
+			for (int j = 0; j < m; j++) {
+				if(i==0 && j== 0)
+					continue;
+				
+				int l = 0;
+				int u = 0;
+				
+				if(i-1>=0)
+					u = map[i-1][j];
+				if(j-1>=0)
+					l = map[i][j-1];
+				
+				map[i][j] += Math.max(u, l);
+			}
+		}
+		
+		System.out.println(map[n-1][m-1]);
+		
+	}
+
+}

--- a/myeonggyu/src/week14/BOJ_2116_G5_주사위쌓기.java
+++ b/myeonggyu/src/week14/BOJ_2116_G5_주사위쌓기.java
@@ -1,0 +1,88 @@
+package week14;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_2116_G5_주사위쌓기 {
+
+	
+	static int n;
+	static int[][] dices;
+	static int[] nextIdx = {5,3,4,1,2,0};
+	
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		n = Integer.parseInt(br.readLine());
+		dices = new int[n][6];
+		for (int i = 0; i < n; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < 6; j++) {
+				dices[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+		
+		int maxs = 0;
+		for (int i = 1; i < 7; i++) {
+			int v = dfs(i);
+			maxs = Math.max(v,maxs);
+//			System.out.println("maxs : " + v);
+		}
+		
+		System.out.println(maxs);
+		
+	}
+
+	private static int dfs(int s) {
+
+		
+		int tmp = 0;
+		int sums = 0;
+		int total = 0;
+		for (int i = 0; i < 6; i++) {
+			if(dices[0][i] == s)
+				tmp = i;
+		}
+		
+		for (int i = 0; i < 6; i++) {
+			if(dices[0][i] == s || dices[0][i] == dices[0][nextIdx[tmp]])
+				continue;
+			sums = Math.max(sums, dices[0][i]);
+		}
+		total += sums;
+		int next = dices[0][nextIdx[tmp]];
+		
+		
+		for (int j = 1; j < n; j++) {
+		
+			tmp = 0;
+			sums = 0;
+			for (int i = 0; i < 6; i++) {
+				if(dices[j][i] == next)
+					tmp = i;
+			}
+//			if(next==6)
+//				System.out.println(1);
+			for (int i = 0; i < 6; i++) {
+				if(dices[j][i] == next || dices[j][i] == dices[j][nextIdx[tmp]])
+					continue;
+				sums = Math.max(sums, dices[j][i]);
+			}
+			
+			
+			total += sums;
+//			System.out.print("max : " + sums);
+//			System.out.print(" pre : " + next);
+			next = dices[j][nextIdx[tmp]];
+//			System.out.println(" next : " + next);
+			
+		}
+		
+		return total;
+		
+		
+	}
+
+}

--- a/myeonggyu/src/week14/BOJ_8394_S3_악수.java
+++ b/myeonggyu/src/week14/BOJ_8394_S3_악수.java
@@ -1,0 +1,30 @@
+package week14;
+
+import java.util.Arrays;
+import java.util.Scanner;
+
+public class BOJ_8394_S3_악수 {
+	
+	public static void main(String[] args) {
+		
+		Scanner sc = new Scanner(System.in);
+		int n = sc.nextInt();
+		
+		int[] l = new int[n];
+		int[] r = new int[n];
+		int[] z = new int[n];
+		l[0] = 0;//왼쪽
+		r[0] = 1;//오른쪽
+		z[0] = 1;//안하기
+		
+		for (int i = 1; i < n; i++) {
+			l[i] = (r[i-1])%10;
+			r[i] = (z[i-1]+l[i-1])%10;
+			z[i] = (l[i-1]+z[i-1])%10;
+			
+		}
+		
+		System.out.println((l[n-1]+z[n-1])%10);
+	}
+
+}

--- a/myeonggyu/src/week14/PG_카카오블라인드_LV2_캐시.py
+++ b/myeonggyu/src/week14/PG_카카오블라인드_LV2_캐시.py
@@ -1,0 +1,49 @@
+from collections import defaultdict
+
+
+def solution(cacheSize, cities):
+    dic = defaultdict(int)
+
+    sets = set()
+    cnt = 0
+    times = 0
+    for i, c in enumerate(cities):
+
+        c = "".join([x.lower() for x in c])
+        # print(dic)
+        # print(sets)
+
+        if cacheSize == 0:
+            times += 5
+            continue
+
+        if c in sets:
+            times += 1
+            dic[c] = i
+            continue
+
+
+        else:
+
+            if cnt < cacheSize:
+                sets.add(c)
+                cnt += 1
+                dic[c] = i
+                times += 5
+                continue
+
+            mins = 1e9
+            key = 0;
+            for k in dic:
+                idx = dic[k]
+                if mins > idx:
+                    mins = idx
+                    key = k
+            sets.remove(key)
+            del (dic[key])
+
+            sets.add(c)
+            dic[c] = i
+            times += 5
+
+    return times

--- a/myeonggyu/src/week15/BOJ_20922_S1_겹치는건싫어.java
+++ b/myeonggyu/src/week15/BOJ_20922_S1_겹치는건싫어.java
@@ -1,0 +1,55 @@
+package week15;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.StringTokenizer;
+
+public class BOJ_20922_S1_겹치는건싫어 {
+	
+	public static void main(String[] args) throws IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int n = Integer.parseInt(st.nextToken());
+		int k = Integer.parseInt(st.nextToken());
+		int[] arr = new int[n];
+		
+		st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < arr.length; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		
+		int l = 0;
+		int r = 0;
+		int max = 0;
+		HashMap<Integer, Integer> hash = new HashMap<>();
+		while(r<n) {
+			if(hash.containsKey(arr[r])) {
+				
+				if(hash.get(arr[r])==k) {
+					while(hash.get(arr[r]) == k) {
+						hash.put(arr[l], hash.get(arr[l])-1);
+						l++;
+					}
+				}
+				else {
+					hash.put(arr[r], hash.get(arr[r])+1);
+					r++;
+				}
+			}
+			else {
+				hash.put(arr[r], 1);
+				r++;
+			}
+			
+			max = Math.max(max, r-l);
+		}
+		
+		System.out.println(max);
+		
+	}
+
+}

--- a/myeonggyu/src/week15/BOJ_23291_P5_어항정리.java
+++ b/myeonggyu/src/week15/BOJ_23291_P5_어항정리.java
@@ -1,0 +1,229 @@
+package week15;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ_23291_P5_어항정리 {
+
+	
+	static int n;
+	static int k;
+	static int[][] map;
+	static int[][] diff = {{1,0},{0,1},{-1,0},{0,-1}};	
+	
+	public static void main(String[] args) throws IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		n =Integer.parseInt(st.nextToken());
+		k = Integer.parseInt(st.nextToken());
+		map = new int[n][n];
+		int total = 0;
+		
+		
+		st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < n; i++) {
+			map[0][i] = Integer.parseInt(st.nextToken());
+		}
+		
+		if(checkCount())
+		{
+			System.out.println(0);
+			return;
+		}
+		
+		while(true) {
+			
+			ArrayList<Integer> arr = new ArrayList<>();
+			int mins = (int)1e9;
+			for (int i = 0; i < n; i++) {
+				if(map[0][i] < mins) {
+					mins = map[0][i];
+					arr.clear();
+					arr.add(i);
+				}
+				else if(map[0][i] == mins) {
+					arr.add(i);
+				}
+			}
+			
+			for (Integer i : arr) {
+				map[0][i] += 1;
+			}
+		
+		//1번 정리
+			int cidx = 1;
+			int dept = 1;
+			a : while(true) {
+//				System.out.println("cbidx : " + cidx + " dept : " + dept);
+			
+				for (int t = 0; t < 2; t++) {
+					
+					if(cidx+dept+t>n)
+						break a;
+	
+					for (int j = 0; j <dept ; j++) {
+						
+						
+						for (int i = 0; i < dept+t; i++) {
+								map[1+j][cidx+i] = map[i][cidx-1-j];
+								map[i][cidx-1-j] = 0;
+						} 
+					}
+					
+//					print();
+//					System.out.println("----------- cidx :" + cidx + " dept : " + dept);
+					cidx += dept+t;				
+//					System.out.println("cidx : " + cidx + " dept : " + dept);
+					
+				}
+				dept++;
+			}
+			
+//			System.out.println("sort");
+//			print();
+			sort();
+			restore();
+			
+			
+			
+			cidx = (n+1)/2;
+			int dep = n/2;
+			//2번정리
+				
+			for (int t = 0; t < 2; t++) {
+				for (int i = 0; i < t+1; i++) {
+					
+					for (int j = 0; j < dep; j++) {
+						map[1+i+t][cidx+j] = map[t-i][cidx-1-j];
+						map[t-i][cidx-1-j] = 0;
+					}
+				}
+				cidx = (cidx+n+1)/2;
+				dep = dep/2;
+			}
+//			print();
+			sort();
+			restore();
+			
+				
+			total++;
+			if(checkCount())
+				break;
+				
+		}
+		System.out.println(total);
+//		print();
+	}
+
+
+	private static boolean checkCount() {
+		
+		int mins = (int)1e9;
+		int maxs = 0;
+		for (int i : map[0]) {
+			mins = Math.min(i, mins);
+			maxs = Math.max(i, maxs);
+		}
+		
+		return maxs-mins <= k;
+	}
+
+
+	private static void restore() {
+		int[] map2 = new int[n];
+		int idx = 0;
+		for (int j = 0; j < n; j++) {
+			for (int i = 0; i < n; i++) {
+				if(map[i][j] == 0)
+					continue;
+				
+				map2[idx++] = map[i][j];
+				map[i][j] = 0;
+				
+				
+			}
+		}
+		
+		map[0] = Arrays.copyOf(map2, n);
+	}
+
+
+	private static void sort() {
+		
+		int[][] map2 = new int[n][n];
+		for (int i = 0; i < n; i++) {
+			for (int j = 0; j < n; j++) {
+				if(map[i][j]==0)
+					continue;
+				
+				map2[i][j] = map[i][j];
+			}
+		}
+		
+		boolean[][] visited = new boolean[n][n];
+		
+		
+		
+		for (int i = 0; i < n; i++) {
+			for (int j = 0; j < n; j++) {
+				if(map[i][j]==0)
+					continue;
+				
+				visited[i][j] = true;
+				
+				for (int[] d : diff) {
+					int nr = i+d[0];
+					int nc = j+d[1];
+					
+					if(!check(nr,nc))
+						continue;
+					
+					if(map[nr][nc] == 0)
+						continue;
+					
+					if(visited[nr][nc])
+						continue;
+					
+					
+					int di = map[nr][nc]-map[i][j];
+					int v = Math.abs(di)/5;
+					
+					if(di <0) {
+						map2[nr][nc] += v;
+						map2[i][j] -= v;
+					}
+					else {
+						map2[nr][nc] -= v;
+						map2[i][j] += v;
+					}
+				}
+			}
+		}
+		
+		
+		for (int i = 0; i < n; i++) {
+			for (int j = 0; j < n; j++) {
+				map[i][j] = map2[i][j];
+			}
+		}
+		
+	}
+
+	private static boolean check(int nr, int nc) {
+		return 0 <= nr && nr < n && 0 <= nc && nc < n;
+	}
+
+	private static void print() {
+		for (int[] is : map) {
+			System.out.println(Arrays.toString(is));
+		}
+	}
+	
+	
+
+}

--- a/myeonggyu/src/week15/PG_LV2_전력망을둘로나누기.py
+++ b/myeonggyu/src/week15/PG_LV2_전력망을둘로나누기.py
@@ -1,0 +1,51 @@
+from collections import defaultdict
+from collections import deque
+
+def solution(n, wires):
+    m = len(wires)
+    min_cnt = 1e9
+    for j in range(m):
+
+        cnt = 0
+        dic = defaultdict(list)
+
+        for i in range(m):
+            if i == j:
+                continue
+            dic[wires[i][0]].append(wires[i][1])
+            dic[wires[i][1]].append(wires[i][0])
+
+        visited = [False for _ in range(n+1)]
+        queue = deque()
+        queue.append(1)
+
+        while queue:
+            c = queue.popleft()
+            if visited[c]:
+                continue
+            visited[c] = True
+            cnt += 1
+            tmp = dic[c]
+            for x in tmp:
+                queue.append(x)
+
+        for i in range(n+1):
+            if i != 0 and not(visited[i]):
+                x = i
+                break
+
+        queue.append(x)
+        while queue:
+            c = queue.popleft()
+            if visited[c]:
+                continue
+            visited[c] = True
+            cnt -= 1
+            tmp = dic[c]
+            for x in tmp:
+                queue.append(x)
+        cnt = abs(cnt)
+        if min_cnt > cnt:
+            min_cnt = cnt
+
+    return min_cnt

--- a/myeonggyu/src/week15/SWEA_2105_디저트카페.java
+++ b/myeonggyu/src/week15/SWEA_2105_디저트카페.java
@@ -1,0 +1,169 @@
+package week15;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class SWEA_2105_디저트카페 {
+	
+	static int n;
+	static int[][] map;
+	static int[][] diff = {{1,1},{1,-1},{-1,-1},{-1,1}};
+	static int total;
+	
+	static class Node{
+		
+		int r;
+		int c;
+		int d;
+		int sums;
+		HashSet<Integer> hash;
+		
+		public Node(int r, int c, int d, int sums, HashSet<Integer> set) {
+			this.r = r;
+			this.c = c;
+			this.d = d;
+			this.sums = sums;
+			this.hash = set;
+		}
+
+		@Override
+		public String toString() {
+			return "Node [r=" + r + ", c=" + c + ", d=" + d + ", sums=" + sums + ", hash=" + hash + "]";
+		}
+		
+		
+
+	}
+	
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		int T = Integer.parseInt(br.readLine());
+		for (int t = 1; t <= T; t++) {
+			
+			
+			n = Integer.parseInt(br.readLine());
+			map = new int[n][n];
+			for (int i = 0; i < n; i++) {
+				StringTokenizer st = new StringTokenizer(br.readLine());
+				for (int j = 0; j < n; j++) {
+					map[i][j] = Integer.parseInt(st.nextToken());
+					
+				}
+			}
+			
+			
+			total = 0;
+			for (int i = 0; i < n; i++) {
+				for (int j = 0; j < n; j++) {
+					if(i==0) {
+						if(j==0 || j== n-1)
+							continue;
+					}
+					
+					if(j==0) {
+						if(i==0 || i == n-1)
+							continue;
+					}
+					
+					
+//					System.out.println("i : "+ i + " j : " + j);
+					bfs(i,j);
+				}
+			}
+			if(total == 0)
+				total = -1;
+			System.out.println("#" + t + " " + total);
+			
+		}
+	}
+
+	private static void bfs(int i, int j) {
+
+		Queue<Node> queue = new LinkedList<>();
+		HashSet<Integer> s = new HashSet<>();
+		s.add(map[i][j]);
+		queue.offer(new Node(i,j,0,1,s));
+		
+		
+		while(!queue.isEmpty()) {
+			Node node = queue.poll();
+//			System.out.println(node);
+			
+			
+			a : for (int d = 0; d < 4; d++) {
+				if(d==node.d){
+					
+					int nr = node.r + diff[d][0];
+					int nc = node.c + diff[d][1];
+					
+					if(!check(nr,nc))
+						continue;
+					
+					if(node.d == 3 && equals(new int[] {nr,nc},new int[] {i,j})) {
+						total = Math.max(total, node.sums);
+						continue a;
+					}
+					
+					if(node.hash.contains(map[nr][nc]))
+						continue;
+					
+					HashSet<Integer> tmp = new HashSet<>();
+					for (Integer idx : node.hash) {
+						tmp.add(idx);
+					}
+					tmp.add(map[nr][nc]);
+					queue.offer(new Node(nr,nc,node.d,node.sums+1, tmp));
+				}
+				
+				if(node.r == i && node.c == j)
+					continue;
+				
+				else if(node.d+1 < 4 && d==node.d+1){
+					int nr = node.r + diff[d][0];
+					int nc = node.c + diff[d][1];
+					
+					if(!check(nr,nc))
+						continue;
+					
+					if(node.d == 2 && equals(new int[] {nr,nc},new int[] {i,j})) {
+						total = Math.max(total, node.sums);
+						continue a;
+					}
+
+					if(node.hash.contains(map[nr][nc]))
+						continue;
+					
+					HashSet<Integer> tmp = new HashSet<>();
+					for (Integer idx : node.hash) {
+						tmp.add(idx);
+					}
+					tmp.add(map[nr][nc]);
+						
+					queue.offer(new Node(nr,nc,node.d+1,node.sums+1, tmp));
+				}
+			}
+		}
+		
+		
+	}
+
+	private static boolean check(int nr, int nc) {
+		return 0 <= nr && nr < n && 0 <= nc && nc < n;
+	}
+
+	private static boolean equals(int[] is, int[] arr) {
+		return is[0] == arr[0] && is[1] == arr[1];
+	}
+	
+	
+
+}

--- a/myeonggyu/src/week16/BOJ_1079_G2_마피아.java
+++ b/myeonggyu/src/week16/BOJ_1079_G2_마피아.java
@@ -1,0 +1,113 @@
+package week16;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_1079_G2_마피아 {
+
+	static int n;
+	static int[] scores;
+	static int[][] relation;
+	static int myNumber;
+	static boolean[] deadPeople;
+	static int res = 0;
+	
+	public static void main(String[] args) throws NumberFormatException, IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		n = Integer.parseInt(br.readLine());
+		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		scores = new int[n];
+		relation = new int[n][n];
+		for (int i = 0; i < n; i++) {
+			scores[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		for (int i = 0; i < n; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < n; j++) {
+				relation[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+		
+		myNumber = Integer.parseInt(br.readLine());
+		deadPeople = new boolean[n];
+		//현재 사람수, 죽인사람 배열을 들고 게임을 시작
+		search(n, 0);
+		
+		System.out.println(res);
+		
+	}
+
+	private static void search(int cnt, int night) {
+
+		
+		if(cnt==1 || deadPeople[myNumber] == true) {
+			res = Math.max(res, night);
+			return;
+		}
+		
+		//밤이면
+		if(cnt%2 == 0) {
+			
+			for (int i = 0; i < n; i++) {
+				if(deadPeople[i])
+					continue;
+				
+				if(i==myNumber)
+					continue;
+				
+				deadPeople[i] = true;
+				changeScore(i,1);
+				search(cnt-1, night+1);
+				deadPeople[i] = false;
+				changeScore(i, -1);
+				
+			}
+			
+		}
+		//낮이면
+		else {
+			
+			int maxIdx = 0;
+			int maxs = 0;
+			for (int i = 0; i < n; i++) {
+				
+				if(deadPeople[i])
+					continue;
+				
+				if(maxs < scores[i]) {
+					maxs = scores[i];
+					maxIdx = i;
+				}
+				else if(maxs == scores[i]) {
+					if(maxIdx > i)
+						maxIdx = i;
+				}
+			}
+			
+			deadPeople[maxIdx] = true;
+			search(cnt-1, night);
+			deadPeople[maxIdx] = false;
+			
+		}
+		
+	}
+
+	private static void changeScore(int idx, int type) {
+		for (int i = 0; i < n; i++) {
+			
+			if(i == idx)
+				continue;
+			
+			if(type == 1)
+				scores[i] += relation[idx][i];
+			else
+				scores[i] -= relation[idx][i];
+		}
+	}
+
+}

--- a/myeonggyu/src/week16/BOJ_2665_G4_미로만들기.java
+++ b/myeonggyu/src/week16/BOJ_2665_G4_미로만들기.java
@@ -1,0 +1,102 @@
+package week16;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BOJ_2665_G4_미로만들기 {
+	
+	static int n;
+	static int[][] map;
+	static int[][] diff = {{0,1},{1,0},{0,-1},{-1,0}};
+	
+	static class Node implements Comparable<Node>{
+		
+		int r;
+		int c;
+		int bCnt;
+		public Node(int r, int c, int bCnt) {
+			super();
+			this.r = r;
+			this.c = c;
+			this.bCnt = bCnt;
+		}
+		public Node() {
+			super();
+			// TODO Auto-generated constructor stub
+		}
+		@Override
+		public String toString() {
+			return "Node [r=" + r + ", c=" + c + ", bCnt=" + bCnt + "]";
+		}
+		@Override
+		public int compareTo(Node o) {
+			return Integer.compare(this.bCnt,o.bCnt);
+		}
+		
+		
+	}
+	
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		n = Integer.parseInt(br.readLine());
+		
+		map = new int[n][n];
+		
+		StringTokenizer st;
+		for (int i = 0; i < n; i++) {
+
+			String[] tmp = br.readLine().split("");
+			for (int j = 0; j < n; j++) {
+				map[i][j] = (Integer.parseInt(tmp[j])+1)%2;
+			}
+		}
+		
+		int res = bfs();
+		System.out.println(res);
+		
+	}
+
+	private static int bfs() {
+
+		PriorityQueue<Node> pq = new PriorityQueue<>();
+		pq.offer(new Node(0,0,0));
+		boolean[][] visited = new boolean[n][n];
+		
+		while(!pq.isEmpty()) {
+			
+			Node cur = pq.poll();
+			visited[cur.r][cur.c] = true;
+			
+			if(cur.r == n-1 && cur.c == n-1)
+				return cur.bCnt;
+			
+			for (int[] d : diff) {
+				int nr = cur.r + d[0];
+				int nc = cur.c + d[1];
+				
+				if(!check(nr,nc))
+					continue;
+				
+				if(visited[nr][nc])
+					continue;
+				
+				pq.offer(new Node(nr,nc,cur.bCnt+map[nr][nc]));
+			}
+			
+		}
+		
+		return 0;
+	}
+
+	private static boolean check(int nr, int nc) {
+		return 0 <= nr && nr < n && 0 <= nc && nc < n;
+	}
+
+}

--- a/myeonggyu/src/week16/PG_코딩테스트연습_LV2_구명보트.py
+++ b/myeonggyu/src/week16/PG_코딩테스트연습_LV2_구명보트.py
@@ -1,0 +1,21 @@
+def solution(people, limit):
+    answer = 0
+    people.sort()
+
+    i = 0
+    j = len(people) - 1
+
+    while i <= j:
+        sums = people[i] + people[j]
+        if i == j:
+            answer += 1
+            break
+        if sums > limit:
+            answer += 1
+            j -= 1
+        else:  # 2명제한
+            i += 1
+            j -= 1
+            answer += 1
+
+    return answer

--- a/myeonggyu/src/week16/SWEA_2115_모의_벌꿀채취.java
+++ b/myeonggyu/src/week16/SWEA_2115_모의_벌꿀채취.java
@@ -1,0 +1,141 @@
+package week16;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class SWEA_2115_모의_벌꿀채취 {
+
+	static int n;
+	static int m;
+	static int c;
+	static int[][] map;
+	static int[] honeyA;
+	static int[] honeyB;
+	
+	static int score;
+	
+	static int[] arr;
+	
+	public static void main(String[] args) throws NumberFormatException, IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int T = Integer.parseInt(br.readLine());
+		
+		for (int t = 1; t <= T; t++) {
+			
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			n = Integer.parseInt(st.nextToken());
+			m = Integer.parseInt(st.nextToken());
+			c = Integer.parseInt(st.nextToken());
+			
+			map = new int[n][n];
+			
+			for (int i = 0; i < n; i++) {
+				
+				st = new StringTokenizer(br.readLine());
+				
+				for (int j = 0; j < n; j++) {
+					map[i][j] = Integer.parseInt(st.nextToken());
+				}
+			}
+			
+			int totalScore = 0;
+			honeyA = new int[m];
+			honeyB = new int[m];
+			
+			for (int i = 0; i < n; i++) {
+				for (int j = 0; j <= n-m; j++) {
+					
+					for (int a = 0; a < m; a++) {
+						honeyA[a] = map[i][j+a];
+					}
+					
+					
+					score = 0;
+					findScore(honeyA);
+					int scoreA = score; 
+					
+					
+					if(i==n-1 && j > n-(2*m))
+						break;
+					
+					for (int r = i; r < n; r++) {
+						for (int c = 0; c <= n-m; c++) {
+							
+							int cc = c;
+							
+							if(r == i) {
+								cc = j+m+c;
+							}
+
+							if(cc+m>n)
+								break;
+							
+							
+							for (int a = 0; a < m; a++) {
+								honeyB[a] = map[r][cc+a];
+							}
+						
+							
+							score = 0;
+							findScore(honeyB);
+							int scoreB = score;
+							
+							totalScore = Math.max(totalScore, scoreA + scoreB);
+						
+						}
+					}
+					
+				}
+			}
+			
+			System.out.println("#"+t+" " + totalScore);
+			
+		}
+		
+	}
+
+	private static void findScore(int[] honey) {
+
+		for (int i = 1; i <= honey.length; i++) {
+			arr = new int[i];
+			subset(0,0,i,honey);
+		}
+		
+	}
+
+	private static void subset(int start, int cnt, int len, int[] honey) {
+
+		if(cnt==len) {
+			int sums = 0;
+			
+			for (int i = 0; i < len; i++) {
+				sums += arr[i];
+			}
+			
+			if(sums > c)
+				return;
+			
+			sums = 0;
+			for (int i = 0; i < len; i++) {
+				sums += arr[i]*arr[i];
+			}
+			
+			score = Math.max(score, sums);
+			
+		}
+		else {
+			
+			for (int i = start; i < m; i++) {
+				arr[cnt] = honey[i];
+				subset(i+1,cnt+1,len,honey);
+			}
+			
+		}
+		
+	}
+
+}

--- a/myeonggyu/src/week17/BOJ_16235_G3_나무재테크.java
+++ b/myeonggyu/src/week17/BOJ_16235_G3_나무재테크.java
@@ -1,0 +1,161 @@
+package week17;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.StringTokenizer;
+
+public class BOJ_16235_G3_나무재테크 {
+
+	static class Status{
+		
+		int nut;
+		ArrayList<Integer> trees;
+		
+		public Status(int nut, ArrayList<Integer> trees) {
+			super();
+			this.nut = nut;
+			this.trees = trees;
+		}
+		public Status() {
+			super();
+			trees = new ArrayList<>();
+		}
+		@Override
+		public String toString() {
+			return "Status [nut=" + nut + ", trees=" + trees + "]";
+		}
+		
+	}
+	
+	static int[][] diff = {{1,0},{0,1},{-1,0},{0,-1},{1,1},{-1,-1},{-1,1},{1,-1}};
+	static int n;
+	
+	public static void main(String[] args) throws IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+
+		n = Integer.parseInt(st.nextToken());
+		int m = Integer.parseInt(st.nextToken());
+		int k = Integer.parseInt(st.nextToken());
+		
+		int[][] nut = new int[n][n];
+		Status[][] map = new Status[n][n];
+		int[][] summer = new int[n][n];
+		
+		for (int i = 0; i < n; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < n; j++) {
+				nut[i][j] = Integer.parseInt(st.nextToken());
+				map[i][j] = new Status(5,new ArrayList<>());
+			}
+		}
+		
+		for (int i = 0; i < m; i++) {
+			st = new StringTokenizer(br.readLine());
+
+			int r = Integer.parseInt(st.nextToken())-1;
+			int c = Integer.parseInt(st.nextToken())-1;
+			int a = Integer.parseInt(st.nextToken());
+			
+			map[r][c].trees.add(a);
+		}
+		
+		while(k != 0) {
+			
+			//봄
+
+//			System.out.println("k : " + k);
+			
+			for (int i = 0; i < n; i++) {
+				for (int j = 0; j < n; j++) {
+					Status s = map[i][j];
+					
+					Collections.sort(s.trees);
+					for (int idx = 0; idx < s.trees.size(); idx++) {
+						if(s.nut - s.trees.get(idx) < 0) {
+							
+							summer[i][j] += s.trees.get(idx)/2;							
+							s.trees.remove(idx);
+							idx--;
+						}
+						else {
+							s.nut -= s.trees.get(idx);
+							s.trees.set(idx, s.trees.get(idx)+1);
+						}
+					}
+					
+//					System.out.println("i : " + i + " j : " + j + " trees : " +s.trees.toString());
+				
+				}
+			}
+			
+			//여름
+			for (int i = 0; i < n; i++) {
+				for (int j = 0; j < n; j++) {
+					Status s = map[i][j];
+					s.nut += summer[i][j];
+					summer[i][j] = 0;
+				}
+			}
+			
+			//가을
+			for (int i = 0; i < n; i++) {
+				for (int j = 0; j < n; j++) {
+					Status s = map[i][j];
+					
+					for (int idx = 0; idx < s.trees.size(); idx++) {
+						int tree = s.trees.get(idx);
+						
+						if(tree % 5 == 0) {
+							for (int[] d : diff) {
+								int nr = i + d[0];
+								int nc = j + d[1];
+								
+								if(!check(nr,nc))
+									continue;
+								
+								map[nr][nc].trees.add(1);
+							}
+						}
+					}
+				}
+			}
+			
+			//겨울
+			for (int i = 0; i < n; i++) {
+				for (int j = 0; j < n; j++) {
+					
+					Status s = map[i][j];
+					s.nut += nut[i][j];
+					
+				}
+			}
+			
+			
+			k--;
+			
+			
+		}
+		
+		int sums = 0;
+		
+		for (int i = 0; i < n; i++) {
+			for (int j = 0; j < n; j++) {
+				sums += map[i][j].trees.size();
+			}
+		}
+		
+		System.out.println(sums);
+	}
+
+
+	private static boolean check(int nr, int nc) {
+		return 0 <= nr && nr < n && 0 <= nc && nc < n;
+	}
+
+}

--- a/myeonggyu/src/week17/BOJ_17140_G4_이차원배열과연산.java
+++ b/myeonggyu/src/week17/BOJ_17140_G4_이차원배열과연산.java
@@ -1,0 +1,199 @@
+package week17;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class BOJ_17140_G4_이차원배열과연산 {
+
+	static int r;
+	static int c;
+	static int k;
+	static int[][] map;
+	
+	static class Num implements Comparable<Num>{
+		int n;
+		int cnt;
+		public Num(int n, int cnt) {
+			super();
+			this.n = n;
+			this.cnt = cnt;
+		}
+		public Num() {
+			super();
+			// TODO Auto-generated constructor stub
+		}
+		@Override
+		public String toString() {
+			return "Num [n=" + n + ", cnt=" + cnt + "]";
+		}
+		@Override
+		public int compareTo(Num o) {
+			if(this.cnt==o.cnt) {
+				return Integer.compare(this.n, o.n);
+			}
+			else {
+				return Integer.compare(this.cnt, o.cnt);				
+			}
+		}
+		
+		
+	}
+	
+	public static void main(String[] args) throws IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		r = Integer.parseInt(st.nextToken());
+		c = Integer.parseInt(st.nextToken());
+		k = Integer.parseInt(st.nextToken());
+		
+		map = new int[3][3];
+		
+		for (int i = 0; i < 3; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < 3; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+		
+		System.out.println(simulation());
+				
+	}
+
+	private static int simulation() {
+
+		int t = 0;
+		
+		while(t <= 100) {
+			
+			//행연산인지 열연산인지
+			if( r-1 < map.length && c-1 < map[0].length && map[r-1][c-1] == k)
+				return t;
+			calc();
+//			for (int[] is : map) {
+//				System.out.println(Arrays.toString(is));
+//			}
+//			System.out.println("-----------");
+			t++;
+			
+		}
+		
+		return -1;
+		
+	}
+
+	private static void calc() {
+		int rCnt = map.length;
+		int cCnt = map[0].length;
+		if(rCnt >= cCnt) {
+			
+			ArrayList<Num>[] arr = new ArrayList[rCnt];
+			int maxCcnt = 0;
+			for (int i = 0; i < rCnt; i++) {
+				
+				arr[i] = new ArrayList<>();
+				int[] nums = new int[101];
+				
+				for (int j = 0; j < cCnt; j++) {
+					if(map[i][j] == 0)
+						continue;
+					
+					nums[map[i][j]] += 1;
+					
+				}
+				
+				for (int j = 1; j < 101; j++) {
+					if(nums[j] == 0)
+						continue;
+					
+					arr[i].add(new Num(j,nums[j]));
+					if(arr[i].size()==50)
+						break;
+				}
+				
+				Collections.sort(arr[i]);
+				maxCcnt = Math.max(maxCcnt, arr[i].size()*2);
+				
+			}
+			
+			map = new int[rCnt][maxCcnt];
+			for (int i = 0; i < rCnt; i++) {
+				
+				int idx = 0;
+				for (int j = 0; j < maxCcnt; j++) {
+					
+					if(idx < arr[i].size()) {
+						map[i][j] = arr[i].get(idx).n;
+						map[i][j+1] = arr[i].get(idx).cnt;
+						idx++;
+						j++;
+					}
+					else {
+						map[i][j] = 0;
+					}
+				}
+			}
+			
+		}
+		
+		//열연산
+		else {
+			
+			ArrayList<Num>[] arr = new ArrayList[cCnt];
+			int maxRcnt = 0;
+			for (int j = 0; j < cCnt; j++) {
+				
+				arr[j] = new ArrayList<>();
+				int[] nums = new int[101];
+				
+				for (int i = 0; i < rCnt; i++) {
+					if(map[i][j] == 0)
+						continue;
+					
+					nums[map[i][j]] += 1;
+					
+				}
+				
+				for (int i = 1; i < 101; i++) {
+					if(nums[i] == 0)
+						continue;
+					
+					arr[j].add(new Num(i,nums[i]));
+					if(arr[j].size() == 50)
+						break;
+				}
+				
+				Collections.sort(arr[j]);
+				maxRcnt = Math.max(maxRcnt, arr[j].size()*2);
+				
+			}
+			
+			map = new int[maxRcnt][cCnt];
+			for (int j = 0; j < cCnt; j++) {
+				int idx = 0;
+				for (int i = 0; i < maxRcnt; i++) {
+					
+					if(idx < arr[j].size()) {
+						map[i][j] = arr[j].get(idx).n;
+						map[i+1][j] = arr[j].get(idx).cnt;
+						i++;
+						idx++;
+					}
+					else {
+						map[i][j] = 0;
+					}
+				}
+			}
+			
+		}
+		
+	}
+
+}

--- a/myeonggyu/src/week17/BOJ_21924_G4_도시건설.java
+++ b/myeonggyu/src/week17/BOJ_21924_G4_도시건설.java
@@ -1,0 +1,129 @@
+package week17;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class BOJ_21924_G4_도시건설 {
+
+	static int n;
+	static int m;
+	static PriorityQueue<Path> pq;
+	static int[] finds;
+	
+	static class Path implements Comparable<Path>{
+		
+		int a;
+		int b;
+		int w;
+		public Path(int a, int b, int w) {
+			super();
+			this.a = a;
+			this.b = b;
+			this.w = w;
+		}
+		public Path() {
+			super();
+			// TODO Auto-generated constructor stub
+		}
+		@Override
+		public String toString() {
+			return "Path [a=" + a + ", b=" + b + ", w=" + w + "]";
+		}
+		@Override
+		public int compareTo(Path o) {
+			return Integer.compare(this.w, o.w);
+		}
+		
+		
+		
+	}
+	
+	public static void main(String[] args) throws IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		
+		long total = 0;
+		
+		Path[] paths = new Path[m];
+		
+		for (int i = 0; i < m; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			int w = Integer.parseInt(st.nextToken());
+			
+			total += w;
+			paths[i] = new Path(a,b,w);
+		}
+		
+		
+		Arrays.sort(paths);
+		finds = new int[n+1];
+		for (int i = 0; i < n+1; i++) {
+			finds[i] = i;
+		}
+
+		int cnt = 1;
+		long sums = 0;
+		
+		for (int i = 0; i < m; i++) {
+			
+			Path p = paths[i];
+			
+			if(find(p.a,p.b))
+				continue;
+			
+			
+			union(p.a,p.b);
+			
+			sums += p.w;
+			cnt++;
+			
+		}
+		
+		
+		if(cnt != n)
+			System.out.println(-1);
+		else
+			System.out.println(total-sums);
+		
+		
+		
+	}
+
+	private static void union(int a, int b) {
+
+		while(finds[a] != a){
+			a = finds[a];
+		}
+		
+		while(finds[b] != b) {
+			b = finds[b];
+		}
+
+		finds[a] = Math.min(a, b);
+		finds[b] = Math.min(a, b);
+		
+	}
+
+	private static boolean find(int a, int b) {
+		while(finds[a] != a){
+			a = finds[a];
+		}
+		
+		while(finds[b] != b) {
+			b = finds[b];
+		}
+		
+		return a==b;
+	}
+
+}

--- a/myeonggyu/src/week17/SWEA_5658_모의_보물상자비밀번호.java
+++ b/myeonggyu/src/week17/SWEA_5658_모의_보물상자비밀번호.java
@@ -1,0 +1,64 @@
+package week17;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.StringTokenizer;
+
+public class SWEA_5658_모의_보물상자비밀번호 {
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int T = Integer.parseInt(br.readLine());
+		for (int t = 1; t <= T; t++) {
+			
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			int n = Integer.parseInt(st.nextToken());
+			int k = Integer.parseInt(st.nextToken());
+			
+			ArrayList<String> arr = new ArrayList<>();
+			String[] tmp = br.readLine().split("");
+			for (int i = 0; i < n; i++) {
+				arr.add(tmp[i]);
+			}
+			
+			HashSet<Integer> hash = new HashSet<>();
+			
+			
+			int rotateCnt = n/4;
+			
+			for (int i = 0; i < rotateCnt; i++) {
+				
+				//회전전에 일단 넣어
+				for (int j = 0; j < 4; j++) {
+					StringBuilder sb = new StringBuilder();
+					for (int ii = 0; ii < rotateCnt; ii++) {						
+						sb.append(arr.get(ii+(j*rotateCnt)));
+					}
+					hash.add(Integer.parseInt(sb.toString(),16));
+				}
+				
+				//회전시켜
+				arr.add(0,arr.get(n-1));
+				arr.remove(arr.size()-1);
+			}
+		
+			int[] res = new int[hash.size()];
+			int idx = 0;
+			for (Integer i : hash) {
+				res[idx] = i;
+				idx++;
+			}
+			
+			Arrays.sort(res);
+			System.out.println("#" + t + " "+res[hash.size()-k]);
+		
+		}
+		
+	}
+
+}

--- a/myeonggyu/src/week18/BOJ_13335_S1_트럭.java
+++ b/myeonggyu/src/week18/BOJ_13335_S1_트럭.java
@@ -1,0 +1,99 @@
+package week18;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class BOJ_13335_S1_트럭 {
+	
+	static int n;
+	static int w;
+	static int l;
+	static int[] trucks;
+	
+	static class Truck{
+		
+		int w;
+		int curTime;
+		public Truck() {
+			super();
+			// TODO Auto-generated constructor stub
+		}
+		public Truck(int w, int curTime) {
+			super();
+			this.w = w;
+			this.curTime = curTime;
+		}
+		@Override
+		public String toString() {
+			return "Truck [w=" + w + ", curTime=" + curTime + "]";
+		}
+		
+		
+		
+		
+		
+	}
+	
+	public static void main(String[] args) throws IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		n = Integer.parseInt(st.nextToken());
+		w = Integer.parseInt(st.nextToken());
+		l = Integer.parseInt(st.nextToken());
+		
+		trucks = new int[n];
+		
+		st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < n; i++) {
+			trucks[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		System.out.println(simulation());
+
+	}
+
+	private static int simulation() {
+
+		int idx = 0;
+		int time = 1;
+		int curWeight = trucks[idx];
+		ArrayList<Truck> arr = new ArrayList<>();
+		arr.add(new Truck(trucks[idx],1));
+		while(!arr.isEmpty()) {
+			
+//			for (Truck truck : arr) {
+//				System.out.print(truck);
+//			}
+//			System.out.println("---------");
+//			
+			for (int i = 0; i < arr.size(); i++) {
+				Truck t = arr.get(i);
+				t.curTime += 1;
+				if(t.curTime > w) {
+					curWeight -= t.w;
+					arr.remove(i--);					
+				}
+			}
+			
+			
+			
+			//추가로 트럭이 올라갈 수 있는지 검사
+			if(idx+1 < n && curWeight+trucks[idx+1] <= l) {
+				arr.add(new Truck(trucks[idx+1],1));
+				curWeight += trucks[idx+1];
+				idx++;
+			}
+			
+			time++;
+		}
+		
+		return time;
+		
+	}
+
+}

--- a/myeonggyu/src/week18/BOJ_2792_S2_보석상자.java
+++ b/myeonggyu/src/week18/BOJ_2792_S2_보석상자.java
@@ -1,0 +1,88 @@
+package week18;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class BOJ_2792_S2_보석상자 {
+
+	static int n;
+	static int m;
+	static int[] colors;
+	static int res = 0;
+	
+	public static void main(String[] args) throws IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		
+		
+		colors = new int[m];
+		int maxs = 0;
+		for (int i = 0; i < m; i++) {
+			colors[i] = Integer.parseInt(br.readLine());
+			maxs = Math.max(maxs, colors[i]);
+		}
+		
+		Arrays.sort(colors);
+		
+		binarySearch(0,maxs);
+		System.out.println(res);
+
+		
+	}
+
+	private static void binarySearch(int left,int right) {
+
+		
+		
+		int mid = (right+left)/2;
+		
+		if(mid==left) {
+			
+			if(left==0)
+			{
+				res = right;
+				return;
+			}
+			
+			if(isPossible(left))
+				res = left;
+			else
+				res=right;
+			return;
+		}
+		
+		
+		
+		if(isPossible(mid))
+			binarySearch(left, mid);
+		else
+			binarySearch(mid, right);
+		
+	}
+
+	private static boolean isPossible(int mid) {
+		int cnt = 0;
+		for (int i = m-1; i >= 0; i--) {
+			int c = colors[i];
+			
+			if(c<=mid)
+				break;
+			
+			int v = c%mid==0 ? 0 : 1;
+			v += c/mid;
+			
+			if(cnt+v+m-1 > n)
+				return false;
+			cnt+=(v-1);
+		}
+		return true;
+	}
+
+}

--- a/myeonggyu/src/week18/PG_LV2_점프와순간이동.py
+++ b/myeonggyu/src/week18/PG_LV2_점프와순간이동.py
@@ -1,0 +1,2 @@
+def solution(n):
+    return bin(n).count('1')

--- a/myeonggyu/src/week18/PG_카카오블라인드_LV2_방금그곡.py
+++ b/myeonggyu/src/week18/PG_카카오블라인드_LV2_방금그곡.py
@@ -1,0 +1,73 @@
+
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+18
+19
+20
+21
+22
+23
+24
+25
+26
+27
+28
+29
+30
+31
+32
+33
+34
+35
+36
+37
+def solution(c, musicinfos):
+    answer = ['0000',0]
+    shap = c.count('#')
+    for i in musicinfos:
+
+        music = i.split(',')
+        sh, sm, eh, em = music[0][:2],music[0][-2:],music[1][:2],music[1][-2:]
+        m=int(em)-int(sm)
+        h=int(eh)-int(sh)
+        shp=music[3].count('#')
+        if m<0:
+            h -= 1
+            m = 60+m
+        time =h*60+m
+
+        if time + shp < len(music):
+            code = music[3][:time]
+        else:
+            code = music[3]*((time+shp//len(music[3])) + 2)
+        for k in range(len(code)):
+
+            if time + shap + 1 < k:
+                continue
+            if len(c)+1+k > len(code):
+                continue
+
+            if ''.join(code[k:len(c)+k]) == c:
+                if code[len(c)+k] == '#':
+                    continue
+                if answer[1]< time:
+                    answer = [music[2],time]
+
+    if answer[0] == '0000':
+        return '(None)'
+    else:
+        return answer[0]

--- a/myeonggyu/src/week19/BOJ_13164_G5_행복유치원.java
+++ b/myeonggyu/src/week19/BOJ_13164_G5_행복유치원.java
@@ -1,0 +1,81 @@
+package week19;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class BOJ_13164_G5_행복유치원 {
+	
+	static class Node implements Comparable<Node>{
+		
+		int idx;
+		int w;
+		public Node(int idx, int w) {
+			super();
+			this.idx = idx;
+			this.w = w;
+		}
+		public Node() {
+			super();
+			// TODO Auto-generated constructor stub
+		}
+		@Override
+		public String toString() {
+			return "Node [idx=" + idx + ", w=" + w + "]";
+		}
+		@Override
+		public int compareTo(Node o) {
+			return Integer.compare(o.w, this.w);
+		}
+		
+		
+		
+	}
+
+	public static void main(String[] args) throws IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int n = Integer.parseInt(st.nextToken());
+		int k = Integer.parseInt(st.nextToken());
+		
+		int[] students = new int[n];
+		
+		st = new StringTokenizer(br.readLine());
+		PriorityQueue<Node> pq = new PriorityQueue<>();
+		for (int i = 0; i < n; i++) {
+			students[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		for (int i = 0; i < n-1; i++) {
+			pq.offer(new Node(i,students[i+1]-students[i]));
+		}
+		
+		int[] idx = new int[k-1];
+		int i = 0;
+		while(k != 1) {
+			
+			idx[i++] = pq.poll().idx;
+			k--;
+			
+		}
+		
+		Arrays.sort(idx);		
+		
+		int left = -1;
+		int sums = 0;
+		for (int j = 0; j < idx.length; j++) {
+			sums += (students[idx[j]] - students[left+1]);
+			left = idx[j];
+		}
+
+		sums += students[n-1] - students[left+1];
+		
+		
+		System.out.println(sums);
+	}
+
+}

--- a/myeonggyu/src/week19/BOJ_2251_G5_물통.java
+++ b/myeonggyu/src/week19/BOJ_2251_G5_물통.java
@@ -1,0 +1,174 @@
+package week19;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BOJ_2251_G5_물통 {
+
+	
+	static class Bucket{
+		
+		int a;
+		int b;
+		int c;
+		public Bucket(int a, int b, int c) {
+			super();
+			this.a = a;
+			this.b = b;
+			this.c = c;
+		}
+		public Bucket() {
+			super();
+			// TODO Auto-generated constructor stub
+		}
+		@Override
+		public String toString() {
+			return "Bucket [a=" + a + ", b=" + b + ", c=" + c + "]";
+		}
+		
+		
+		
+		
+	}
+	
+	static int a;
+	static int b;
+	static int c;
+	static HashSet<Integer> hash;
+	
+	public static void main(String[] args) throws IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		a = Integer.parseInt(st.nextToken());
+		b = Integer.parseInt(st.nextToken());
+		c = Integer.parseInt(st.nextToken());
+		hash = new HashSet<>();
+		
+		bfs();
+		int[] res = new int[hash.size()];
+		int idx = 0;
+		for (Integer i : hash) {
+			res[idx++] = i;
+		}
+		
+		Arrays.sort(res);
+		StringBuilder sb = new StringBuilder();
+		for (int i : res) {
+			sb.append(i+" ");
+		}
+		System.out.println(sb.toString());
+		
+		
+		
+		
+	}
+
+	private static void bfs() {
+		
+		Queue<Bucket> queue = new LinkedList<>();
+		queue.offer(new Bucket(0,0,c));
+		boolean[][][] visited = new boolean[201][201][201];
+		visited[0][0][c] = true;
+		
+		while(!queue.isEmpty()) {
+			
+			Bucket cur = queue.poll();
+			
+			if(cur.a == 0) {
+				if(hash.contains(cur.c))
+					continue;
+				
+				hash.add(cur.c);
+			}
+			
+			//a물을 쏟아
+			if(cur.a != 0) {
+				
+				//b가 꽉차있지 않으면
+				if(cur.b != b) {
+					int diff = Math.min(cur.a,b-cur.b);
+					
+					if(!visited[cur.a-diff][cur.b+diff][cur.c]) {
+					
+						queue.offer(new Bucket(cur.a-diff, cur.b+diff,cur.c));
+						visited[cur.a-diff][cur.b+diff][cur.c] = true;
+					}
+				}
+				//c가 꽉차있지 않으면
+				if(cur.c != c) {
+					int diff = Math.min(cur.a,c-cur.c);
+					
+					if(!visited[cur.a-diff][cur.b][cur.c+diff]) {
+					
+						queue.offer(new Bucket(cur.a-diff, cur.b,cur.c+diff));
+						visited[cur.a-diff][cur.b][cur.c+diff] = true;
+					}
+				}
+				
+			}
+			
+			//b물을 쏟아
+			if(cur.b != 0) {
+				
+				//a가 꽉차있지 않으면
+				if(cur.a != a) {
+					int diff = Math.min(cur.b,a-cur.a);
+
+					if(!visited[cur.a+diff][cur.b-diff][cur.c]) {
+					
+						queue.offer(new Bucket(cur.a+diff, cur.b-diff,cur.c));
+						visited[cur.a+diff][cur.b-diff][cur.c] = true;
+					}
+				}
+				//c가 꽉차있지 않으면
+				if(cur.c != c) {
+					int diff = Math.min(cur.b,c-cur.c);
+
+					if(!visited[cur.a][cur.b-diff][cur.c+diff]) {
+					
+						queue.offer(new Bucket(cur.a, cur.b-diff,cur.c+diff));
+						visited[cur.a][cur.b-diff][cur.c+diff] = true;
+					}
+				}
+				
+			}
+			
+			//c물을 쏟아
+			if(cur.c != 0) {
+				
+				//b가 꽉차있지 않으면
+				if(cur.b != b) {
+					int diff = Math.min(cur.c,b-cur.b);
+					
+					if(!visited[cur.a][cur.b+diff][cur.c-diff]) {
+					
+						queue.offer(new Bucket(cur.a, cur.b+diff,cur.c-diff));
+						visited[cur.a][cur.b+diff][cur.c-diff] = true;
+					}
+				}
+				//a가 꽉차있지 않으면
+				if(cur.a != a) {
+					int diff = Math.min(cur.c,a-cur.a);
+
+					if(!visited[cur.a+diff][cur.b][cur.c-diff]) {
+					
+						queue.offer(new Bucket(cur.a+diff, cur.b,cur.c-diff));
+						visited[cur.a+diff][cur.b][cur.c-diff] = true;
+					}
+				}
+				
+			}
+			
+		}
+		
+	}
+
+}

--- a/myeonggyu/src/week19/BOJ_6549_P5_히스토그램에서가장큰직사각형.java
+++ b/myeonggyu/src/week19/BOJ_6549_P5_히스토그램에서가장큰직사각형.java
@@ -1,0 +1,78 @@
+package week19;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Stack;
+import java.util.StringTokenizer;
+
+public class BOJ_6549_P5_히스토그램에서가장큰직사각형 {
+	
+	public static void main(String[] args) throws IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		
+		while(true) {
+			
+			long maxs = 0;
+			StringTokenizer st = new StringTokenizer(br.readLine());			
+			int n = Integer.parseInt(st.nextToken());
+			
+			if(n==0)
+				break;
+			
+			int[] histogram = new int[n];			
+			for (int i = 0; i < n; i++) {
+				histogram[i] = Integer.parseInt(st.nextToken());
+				
+			}
+			
+			Stack<int[]> stack = new Stack<>();
+			
+			
+			
+			for (int i = 0; i < n; i++) {
+				
+					
+				while(!stack.isEmpty() && stack.peek()[0] >= histogram[i]) {
+					
+					//사각형 계산
+					int[] cur = stack.pop();
+					
+					long width = stack.isEmpty() ? i : i-stack.peek()[1]-1;
+					long height = cur[0];
+					
+					
+					long ans = width*height;
+					maxs = Math.max(ans, maxs);							
+				}
+				
+				
+			
+				
+				stack.push(new int[] {histogram[i],i});
+					
+				
+			}
+			
+			while(!stack.isEmpty()) {
+				
+				int[] cur = stack.pop();
+				
+				long width = stack.isEmpty() ? n : n-stack.peek()[1]-1;
+				long height = cur[0];
+				
+				long ans = width*height;
+				maxs = Math.max(ans, maxs);			
+				
+			}
+			sb.append(maxs+"\n");
+		}
+			
+		System.out.println(sb.toString());
+		
+	}
+
+}

--- a/myeonggyu/src/week19/PG_코딩테스트연습_LV2_조이스틱.py
+++ b/myeonggyu/src/week19/PG_코딩테스트연습_LV2_조이스틱.py
@@ -1,0 +1,34 @@
+def solution(name):
+    sum_c = 0
+    sum_s = 0
+    n = len(name)
+
+    for i in name:
+        change_n = min(abs(ord('A') - ord(i)), abs(91 - ord(i)))
+        sum_c += change_n
+
+    locat = [x for x, v in enumerate(name) if v != "A"]
+    m = len(locat)
+
+    if m == 0:
+        return sum_c
+
+    if locat[0] != 0:
+        locat.insert(0, 0)
+
+    print(locat)
+    for i in range(m - 1):
+        v1 = abs(locat[0] - locat[1])
+        v2 = abs(n + locat[0] - locat[-1])
+        if v1 < v2:
+            locat.pop(0)
+            sum_s += v1
+
+        else:
+            a = locat.pop()
+            locat[0] = a
+            sum_s += v2
+
+        print(locat, v1, v2)
+
+    return sum_s + sum_c

--- a/myeonggyu/src/week20/BOJ_14621_G3_나만안되는연애.java
+++ b/myeonggyu/src/week20/BOJ_14621_G3_나만안되는연애.java
@@ -1,0 +1,121 @@
+package week20;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class BOJ_14621_G3_나만안되는연애 {
+
+	static class Path implements Comparable<Path>{
+		
+		int a;
+		int b;
+		int w;
+		
+		
+		
+		@Override
+		public String toString() {
+			return "Path [a=" + a + ", b=" + b + ", w=" + w + "]";
+		}
+
+
+
+		public Path() {
+			super();
+			// TODO Auto-generated constructor stub
+		}
+
+
+
+		public Path(int a, int b, int w) {
+			super();
+			this.a = a;
+			this.b = b;
+			this.w = w;
+		}
+
+
+
+		@Override
+		public int compareTo(Path o) {
+			return Integer.compare(this.w, o.w);
+		}
+		
+	}
+	
+	static int[] parent;
+	
+	
+	public static void main(String[] args) throws IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int n = Integer.parseInt(st.nextToken());
+		int m = Integer.parseInt(st.nextToken());
+		parent = new int[n+1];
+		for (int i = 0; i < n+1; i++) {
+			parent[i] = i;
+		}
+		int ans = 0;
+		
+		st = new StringTokenizer(br.readLine());
+		int[] gender = new int[n+1];
+		for (int i = 0; i < n; i++) {
+			String x = st.nextToken();
+			gender[i+1] = x.equals("M") ? 1 : 0;
+			
+		}
+		
+		PriorityQueue<Path> pq = new PriorityQueue<>();
+		
+		for (int i = 0; i < m; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			int w = Integer.parseInt(st.nextToken());
+			Path path = new Path(a,b,w);
+			pq.offer(path);
+		}
+		
+		int cnt = 0;
+		while(!pq.isEmpty()) {
+			
+			Path p = pq.poll();
+			
+			if(find(p.a) != find(p.b) && gender[p.a] != gender[p.b]) {
+				
+				union(p.a,p.b);
+				ans += p.w;
+				cnt++;
+			}
+			
+		}
+		
+		if(cnt != n-1)
+			ans = -1;
+		System.out.println(ans);
+		
+	}
+
+	private static void union(int a, int b) {
+		
+		a = find(a);
+		b = find(b);
+
+		parent[a] = Math.min(a, b);
+		parent[b] = Math.min(a, b);
+		
+	}
+
+	private static int find(int a) {
+		while(parent[a] != a) {
+			a = parent[a];
+		}
+		return a;
+	}
+
+}

--- a/myeonggyu/src/week20/BOJ_2110_G4_공유기설치.java
+++ b/myeonggyu/src/week20/BOJ_2110_G4_공유기설치.java
@@ -1,0 +1,87 @@
+package week20;
+
+import java.util.Arrays;
+import java.util.Scanner;
+import java.util.Stack;
+
+public class BOJ_2110_G4_공유기설치 {
+
+	static int[] houses;
+	static int n;
+	static int c;
+	static int answer;
+	
+	public static void main(String[] args) {
+
+		Scanner sc = new Scanner(System.in);
+		n = sc.nextInt();
+		c = sc.nextInt();
+		houses = new int[n];
+		answer = 0;
+		int maxs = 0;
+		for (int i = 0; i < n; i++) {
+			
+			int a = sc.nextInt();
+			houses[i] = a;
+			maxs = Math.max(maxs, houses[i]);
+		}
+		
+		Arrays.sort(houses);
+		binarySearch(1,maxs);
+		System.out.println(answer);
+		
+		
+		
+	}
+
+	private static void binarySearch(int left, int right) {
+
+		int mid = (left+right)/2;
+		if(mid==left) {
+			check(right);
+			check(left);
+			return;
+		}
+		
+		if(check(mid)) {
+			binarySearch(mid, right);
+		}
+		else {
+			binarySearch(left, mid);
+		}
+		
+	}
+
+	private static boolean check(int mid) {
+		
+		Stack<Integer> stack = new Stack<>();
+		int cnt = 0;
+		int k = 0;
+		for (int i = 0; i < n; i++) {
+			
+			if(k==c)
+				break;
+			
+			if(stack.isEmpty()) {
+				stack.push(houses[i]);
+				k++;
+				continue;
+			}
+			
+			if(houses[i] - stack.peek() < mid) {
+				cnt++;
+				if(cnt>n-c)
+					return false;
+			}
+			else {
+				stack.push(houses[i]);
+				k++;
+			}
+		}
+		
+		answer = mid;
+		return true;
+		
+	}
+
+}

--- a/myeonggyu/src/week20/PG_LV2_두큐합같게만들기.py
+++ b/myeonggyu/src/week20/PG_LV2_두큐합같게만들기.py
@@ -1,0 +1,31 @@
+from collections import deque
+
+
+def solution(queue1, queue2):
+    queue1 = deque(queue1)
+    queue2 = deque(queue2)
+    n = len(queue1)
+    sum1 = 0
+    sum2 = 0
+    for i in queue1:
+        sum1 += i
+    for i in queue2:
+        sum2 += i
+
+    cnt = 0
+    while sum1 != sum2:
+
+        if sum1 < sum2:
+            queue1.append(queue2.popleft())
+            sum1 += queue1[-1]
+            sum2 -= queue1[-1]
+        else:
+            queue2.append(queue1.popleft())
+            sum1 -= queue2[-1]
+            sum2 += queue2[-1]
+
+        cnt += 1
+        if cnt >= n * 3:
+            return -1
+
+    return cnt

--- a/myeonggyu/src/week20/PG_LV2_행렬테두리회전하기.py
+++ b/myeonggyu/src/week20/PG_LV2_행렬테두리회전하기.py
@@ -1,0 +1,29 @@
+def solution(rows, columns, queries):
+    maps = [[i * columns + j for j in range(1, columns + 1)] for i in range(rows)]
+    diff = [[1, 0], [0, 1], [-1, 0], [0, -1]]
+    answer = []
+
+    for r1, c1, r2, c2 in queries:
+        r1 -= 1
+        c1 -= 1
+        r2 -= 1
+        c2 -= 1
+        mins = 1e9
+        start = maps[r1][c1]
+        nr = r1
+        nc = c1
+        for d in diff:
+            while nr + d[0] <= r2 and nr + d[0] >= r1 and nc + d[1] <= c2 and nc + d[1] >= c1:
+                pr = nr
+                pc = nc
+                nr += d[0]
+                nc += d[1]
+                maps[pr][pc] = maps[nr][nc]
+                mins = min(mins, maps[pr][pc])
+
+        maps[r1][c1 + 1] = start
+        mins = min(mins, start)
+
+        answer.append(mins)
+
+    return answer


### PR DESCRIPTION
## PG LV2 두 큐 합 같게 만들기 
- 그리디
- https://school.programmers.co.kr/learn/courses/30/lessons/118667



## 풀이

queue1 과 queue2의 길이가 각각 30만까지이다.
완전탐색으로 문제를 푼다면, 두개의 큐를 합친 후, 두개의 큐 중에서 어느쪽을 팝(pop)할것인지와 어느쪽으로 푸시할것인지를 선택해야 한다.

즉, 1번의 시행동안 4번의 경우의 수가 생기므로, 4^cnt의 시간복잡도를 가지게 된다.
이 방법은 cnt값이 15를 넘어가면 10초안에 문제를 해결할 수 없다.

여기서 그리디를 생각했다.

queue1과 queue2의 합을 같게만든다는 건 두 큐의 합의 차이를 최소로 만드는것과 같다.
두개의 수 집합의 합의 차를 최소로 만드는 알고리즘은, sum1 과 sum2를 구한 다음, 둘중에 큰 쪽의 원소를 작은 쪽에게 주는 것이다. 이때 중복을 피해야한다.

queue1과 queue2사이의 원소교환은 queue에 삽입되어있는 순서대로 이루어지고, 이는 곧 두개의 큐를 합친 queue3에서 합이 같은 두개의 큐를 만들어내는것과 같다. 즉, queue의 삽입,삭제 연선을 따라간다면 중복을 고려할 필요가 없다.


만약 queue1과 queue2의 합을 같게 만들 수 없다면, 이는queue3의 원소들을 두 배열로 분리했을 때, 합을 같게 만들 수 없다는 말과 같다. queue1과 queue2로 queue3를 만드는 cnt횟수는 n = len(queue1)이고, queue3에서 두개의 배열로 분리했을때, 최악의 경우의 수는 2n이다. 즉, 두 배열로 분리했을 때 합을 같게 만들 수 없다는것은 cnt > 3*n일때 알 수 있으므로,

return -1은 cnt>3n일때 출력하면 된다. 




## 소스코드
~~~python
from collections import deque

def solution(queue1, queue2):
    
    
    queue1 = deque(queue1)
    queue2 = deque(queue2)
    n = len(queue1)
    sum1 = 0
    sum2 = 0
    for i in queue1:
        sum1 += i
    for i in queue2:
        sum2 += i
    
    cnt = 0
    while sum1 != sum2:
        
        if sum1 < sum2:
            queue1.append(queue2.popleft())
            sum1 += queue1[-1]
            sum2 -= queue1[-1]
        else:
            queue2.append(queue1.popleft())
            sum1 -= queue2[-1]
            sum2 += queue2[-1]
    
        cnt += 1
        if cnt >= n*3:
            return -1
        
        
        
    return cnt
~~~

## 결과 


